### PR TITLE
Make debconf run in noninteractive mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu
 
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
 RUN apt update && apt install -y apache2 php libapache2-mod-php php-mbstring php-fdomdocument php-mysql composer zip && apt-get clean
 RUN update-rc.d apache2 disable
 RUN a2enmod rewrite


### PR DESCRIPTION
Otherwise Docker gets stuck.

Inspired by
https://github.com/phusion/baseimage-docker/issues/58#issuecomment-47995343