### PR TITLE
year_stats_fix

### DIFF
--- a/src/Repository/StatsRepository.php
+++ b/src/Repository/StatsRepository.php
@@ -59,7 +59,7 @@ class StatsRepository
         $returnHistory = [];
         foreach ($history as $item) {
             $date = new \DateTimeImmutable($item['time']);
-            if ($item['action'] === 'RENT') {
+            if ($item['action'] === 'RENT' || $item['action'] === 'FORCERENT') {
                 $rentHistory[$item['bikeNum']] = $item;
                 $stats['rental_count']++;
                 if (isset($returnHistory[$item['bikeNum']])) {
@@ -75,7 +75,7 @@ class StatsRepository
                     ($stats['rent_period']['day_of_week'][$date->format('l')] ?? 0) + 1;
                 $stats['rent_period']['month'][$date->format('F')] =
                     ($stats['rent_period']['month'][$date->format('F')] ?? 0) + 1;
-            } elseif ($item['action'] === 'RETURN' || $item['action'] === 'FORCE_RETURN') {
+            } elseif ($item['action'] === 'RETURN' || $item['action'] === 'FORCERETURN') {
                 $returnHistory[$item['bikeNum']] = $item;
                 $stats['return_station'][$item['parameter']] = ($stats['return_station'][$item['parameter']] ?? 0) + 1;
                 $rentDuration = strtotime($item['time']) - strtotime($rentHistory[$item['bikeNum']]['time']);

--- a/src/Repository/StatsRepository.php
+++ b/src/Repository/StatsRepository.php
@@ -78,7 +78,8 @@ class StatsRepository
             } elseif ($item['action'] === 'RETURN' || $item['action'] === 'FORCERETURN') {
                 $returnHistory[$item['bikeNum']] = $item;
                 $stats['return_station'][$item['parameter']] = ($stats['return_station'][$item['parameter']] ?? 0) + 1;
-                $rentDuration = strtotime($item['time']) - strtotime($rentHistory[$item['bikeNum']]['time']);
+                $rentDuration = strtotime($item['time'])
+                    - strtotime($rentHistory[$item['bikeNum']]['time'] ?? $item['time']);
                 if ($rentDuration > 3600 * 24 * 7) {
                     $this->logger->warning(
                         'Too long rental duration',
@@ -92,8 +93,10 @@ class StatsRepository
                 $stats['total_rental_duration'] += $rentDuration;
                 $stats['longest_rental_duration'] = max($stats['longest_rental_duration'], $rentDuration);
                 $stats['shortest_rental_duration'] = min($stats['shortest_rental_duration'], $rentDuration);
-                $stats['return_station'][$rentHistory[$item['bikeNum']]['parameter']] =
-                    ($stats['return_station'][$rentHistory[$item['bikeNum']]['parameter']] ?? 0) + 1;
+                if (!empty($rentHistory[$item['bikeNum']])) {
+                    $stats['return_station'][$rentHistory[$item['bikeNum']]['parameter']] =
+                        ($stats['return_station'][$rentHistory[$item['bikeNum']]['parameter']] ?? 0) + 1;
+                }
                 unset($rentHistory[$item['bikeNum']]);
             } elseif ($item['action'] === 'REVERT') {
                 unset($rentHistory[$item['bikeNum']]);

--- a/templates/stats.html.twig
+++ b/templates/stats.html.twig
@@ -106,7 +106,7 @@
                             <p class="card-text">
                                 {{ stands[stats.most_popular_return_station].standName }}<br>
                                 <img class="img-fluid" src="{{ stands[stats.most_popular_return_station].standPhoto }}"
-                                     alt="{{ stands[stats.most_popular_rent_station].standName }}"
+                                     alt="{{ stands[stats.most_popular_return_station].standName }}"
                                 />
                             </p>
                         </div>


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed bike rental statistics calculation by properly handling force rent/return actions ('FORCERENT' and 'FORCERETURN')
- Added safety checks and fallbacks for missing rental history data to prevent PHP errors
- Fixed incorrect alt text in return station photo display
- Improved overall robustness of the rental statistics tracking system



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>StatsRepository.php</strong><dd><code>Fix bike rental statistics calculation and edge cases</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Repository/StatsRepository.php

<li>Fixed handling of force rent/return actions by including 'FORCERENT' <br>and 'FORCERETURN' cases<br> <li> Added null check for rental history to prevent undefined index errors<br> <li> Added fallback for rent duration calculation when rental history is <br>missing<br>


</details>


  </td>
  <td><a href="https://github.com/cyklokoalicia/OpenSourceBikeShare/pull/212/files#diff-f755a18e4cee8e74ae77625cc3f6387035b33b743f218b53a1bc0a6da85af19e">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stats.html.twig</strong><dd><code>Fix return station photo alt text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/stats.html.twig

<li>Fixed incorrect alt text in return station photo, was using rent <br>station name instead of return station name<br>


</details>


  </td>
  <td><a href="https://github.com/cyklokoalicia/OpenSourceBikeShare/pull/212/files#diff-392ec559728b7c8048fe8d2ece2c78ded17dcfe7584c6a529857c72364c810f1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information