### PR TITLE
fix parsing of sms in old system

### DIFF
--- a/receive.php
+++ b/receive.php
@@ -12,7 +12,9 @@ require_once "actions-sms.php";
  */
 $rentSystem = $rentSystemFactory->getRentSystem('sms');
 
-$args = preg_split("/\s+/", $sms->getProcessedMessage());//preg_split must be used instead of explode because of multiple spaces
+$smsMessage = strtoupper($sms->getProcessedMessage());
+
+$args = preg_split("/\s+/", $smsMessage);//preg_split must be used instead of explode because of multiple spaces
 
 switch ($args[0]) {
     case "RENT":
@@ -21,7 +23,7 @@ switch ($args[0]) {
         break;
     case "RETURN":
         validateReceivedSMS($sms->getNumber(), count($args), 3, _('with bike number and stand name:') . " RETURN 47 RACKO");
-        $rentSystem->returnBike($sms->getNumber(), $args[1], $args[2], trim(urldecode($sms->getMessage())));
+        $rentSystem->returnBike($sms->getNumber(), $args[1], $args[2], $sms->getProcessedMessage());
         break;
     case "FORCERENT":
         checkUserPrivileges($sms->getNumber());
@@ -31,7 +33,7 @@ switch ($args[0]) {
     case "FORCERETURN":
         checkUserPrivileges($sms->getNumber());
         validateReceivedSMS($sms->getNumber(), count($args), 3, _('with bike number and stand name:') . " FORCERETURN 47 RACKO");
-        $rentSystem->returnBike($sms->getNumber(), $args[1], $args[2], trim(urldecode($sms->getMessage())), TRUE);
+        $rentSystem->returnBike($sms->getNumber(), $args[1], $args[2], $sms->getProcessedMessage(), true);
         break;
     case "LIST":
         //checkUserPrivileges($sms->Number()); //allowed for all users as agreed


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed SMS parsing by converting messages to uppercase.

- Replaced `trim(urldecode())` with `getProcessedMessage()` for consistency.

- Improved handling of multiple spaces in SMS messages.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>receive.php</strong><dd><code>Fix and enhance SMS message parsing logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

receive.php

<li>Converted SMS messages to uppercase for uniform processing.<br> <li> Replaced <code>trim(urldecode())</code> with <code>getProcessedMessage()</code> for better <br>consistency.<br> <li> Ensured proper handling of multiple spaces in SMS messages using <br><code>preg_split</code>.


</details>


  </td>
  <td><a href="https://github.com/cyklokoalicia/OpenSourceBikeShare/pull/233/files#diff-232f8bc1ebf92f0d50c539827e32a4dd4c4fbcafd3eda07900c4fe87c582974c">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>