### PR TITLE
Fix duplicate stand lookup for returned bikes

### DIFF
--- a/src/Repository/StandRepository.php
+++ b/src/Repository/StandRepository.php
@@ -119,9 +119,24 @@ class StandRepository
                 longitude,
                 latitude
             FROM stands
-            WHERE standName = :standName LIMIT 1",
+            WHERE standName = :standName
+            ORDER BY CASE status
+                WHEN :statusActive THEN 0
+                WHEN :statusTechnical THEN 1
+                WHEN :statusHidden THEN 2
+                WHEN :statusVirtual THEN 3
+                WHEN :statusInactive THEN 4
+                ELSE 5
+            END,
+            standId DESC
+            LIMIT 1",
             [
                 'standName' => $standName,
+                'statusActive' => StandStatus::ACTIVE->value,
+                'statusTechnical' => StandStatus::TECHNICAL->value,
+                'statusHidden' => StandStatus::HIDDEN->value,
+                'statusVirtual' => StandStatus::VIRTUAL->value,
+                'statusInactive' => StandStatus::INACTIVE->value,
             ]
         )->fetchAssoc();
 

--- a/tests/Integration/Repository/StandRepositoryTest.php
+++ b/tests/Integration/Repository/StandRepositoryTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BikeShare\Test\Integration\Repository;
+
+use BikeShare\Db\DbInterface;
+use BikeShare\Repository\StandRepository;
+use BikeShare\Test\Integration\BikeSharingKernelTestCase;
+
+class StandRepositoryTest extends BikeSharingKernelTestCase
+{
+    public function testFindItemByNamePrefersActiveDuplicateOverInactiveLegacyStand(): void
+    {
+        $db = self::getContainer()->get(DbInterface::class);
+        $db->query('ALTER TABLE stands DROP INDEX standName');
+
+        try {
+            $db->query(
+                'UPDATE stands SET standName = :duplicateName, status = :status WHERE standId = :standId',
+                [
+                    'duplicateName' => 'STAND5',
+                    'status' => 'inactive',
+                    'standId' => 2,
+                ]
+            );
+
+            $stand = self::getContainer()->get(StandRepository::class)->findItemByName('STAND5');
+
+            $this->assertSame(5, (int)$stand['standId']);
+            $this->assertSame('active', $stand['status']);
+        } finally {
+            $db->query(
+                'UPDATE stands SET standName = :standName, status = :status WHERE standId = :standId',
+                [
+                    'standName' => 'STAND2',
+                    'status' => 'active',
+                    'standId' => 2,
+                ]
+            );
+            $db->query('ALTER TABLE stands ADD UNIQUE KEY standName (standName)');
+        }
+    }
+}

--- a/tests/Unit/Repository/StandRepositoryTest.php
+++ b/tests/Unit/Repository/StandRepositoryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BikeShare\Test\Unit\Repository;
+
+use BikeShare\Db\DbInterface;
+use BikeShare\Db\DbResultInterface;
+use BikeShare\Repository\CityRepository;
+use BikeShare\Repository\StandRepository;
+use PHPUnit\Framework\TestCase;
+
+class StandRepositoryTest extends TestCase
+{
+    public function testFindItemByNamePrefersActiveLegacyDuplicateBeforeInactive(): void
+    {
+        $db = $this->createMock(DbInterface::class);
+        $result = $this->createMock(DbResultInterface::class);
+
+        $db->expects($this->once())
+            ->method('query')
+            ->with(
+                $this->callback(
+                    static fn(string $query): bool => str_contains($query, 'ORDER BY CASE status')
+                        && str_contains($query, 'WHEN :statusActive THEN 0')
+                        && str_contains($query, 'WHEN :statusInactive THEN 4')
+                        && str_contains($query, 'standId DESC')
+                ),
+                [
+                    'standName' => 'REDUTA',
+                    'statusActive' => 'active',
+                    'statusTechnical' => 'technical',
+                    'statusHidden' => 'hidden',
+                    'statusVirtual' => 'virtual',
+                    'statusInactive' => 'inactive',
+                ]
+            )
+            ->willReturn($result);
+
+        $result->expects($this->once())
+            ->method('fetchAssoc')
+            ->willReturn([
+                'standId' => 57,
+                'standName' => 'REDUTA',
+                'status' => 'active',
+            ]);
+
+        $repository = new StandRepository($db, new CityRepository(['Bratislava' => 'Bratislava']));
+
+        $stand = $repository->findItemByName('REDUTA');
+
+        $this->assertSame(57, $stand['standId']);
+        $this->assertSame('active', $stand['status']);
+    }
+}


### PR DESCRIPTION
## Summary
- Prefer visible stand records when resolving a stand by name, so legacy inactive duplicates do not capture returns.
- Add unit and integration regression coverage for duplicate stand names.

## Notes
- Production DB rows for bikes 70 and 153 were fixed manually; this PR only changes code/tests to prevent the issue from recurring.

## Tests
- docker compose exec -T web php -l src/Repository/StandRepository.php
- docker compose exec -T web php -l tests/Unit/Repository/StandRepositoryTest.php
- docker compose exec -T web php -l tests/Integration/Repository/StandRepositoryTest.php
- docker compose exec -T web vendor/bin/phpcs src/Repository/StandRepository.php tests/Unit/Repository/StandRepositoryTest.php tests/Integration/Repository/StandRepositoryTest.php
- docker compose exec -T -e APP_ENV=test web php bin/console load:fixtures
- docker compose exec -T -e APP_ENV=test web vendor/bin/phpunit --filter StandRepositoryTest tests/Unit/Repository/StandRepositoryTest.php tests/Integration/Repository/StandRepositoryTest.php
- docker compose exec -T -e APP_ENV=test web vendor/bin/phpunit --filter 'BikeReturnTest|StandBikeListTest' tests/Application/Controller/Api/Bike/BikeReturnTest.php tests/Application/Controller/Api/Stand/StandBikeListTest.php