### PR TITLE
Fix json_decode() flag position; harden getUserCreditHistory() against missing reason data

### DIFF
--- a/src/Credit/CreditSystem.php
+++ b/src/Credit/CreditSystem.php
@@ -221,11 +221,12 @@ class CreditSystem implements CreditSystemInterface
             $date = new \DateTimeImmutable($entry['time']);
             $parameter = $entry['parameter'];
 
-            $jsonData = json_decode($parameter, true, JSON_THROW_ON_ERROR);
+            $jsonData = json_decode($parameter, true, 512, JSON_THROW_ON_ERROR);
+            $reasonType = CreditChangeType::tryFrom($jsonData['reason']);
             $parsed[] = [
                 'date' => $date,
                 'amount' => (float)($jsonData['amount'] ?? 0),
-                'type' => CreditChangeType::tryFrom($jsonData['reason'])->value ?? 'unknown',
+                'type' => $reasonType instanceof CreditChangeType ? $reasonType->value : 'unknown',
                 'balance' => (float)($jsonData['balance'] ?? 0),
             ];
         }

--- a/src/Credit/CreditSystem.php
+++ b/src/Credit/CreditSystem.php
@@ -222,7 +222,7 @@ class CreditSystem implements CreditSystemInterface
             $parameter = $entry['parameter'];
 
             $jsonData = json_decode($parameter, true, 512, JSON_THROW_ON_ERROR);
-            $reasonType = CreditChangeType::tryFrom($jsonData['reason']);
+            $reasonType = CreditChangeType::tryFrom((string)($jsonData['reason'] ?? ''));
             $parsed[] = [
                 'date' => $date,
                 'amount' => (float)($jsonData['amount'] ?? 0),

--- a/tests/Application/Controller/Api/User/UserCreditHistoryTest.php
+++ b/tests/Application/Controller/Api/User/UserCreditHistoryTest.php
@@ -65,12 +65,14 @@ class UserCreditHistoryTest extends BikeSharingWebTestCase
 
     public static function reasonProvider(): iterable
     {
-        yield 'known reason' => [CreditChangeType::CREDIT_ADD->value, CreditChangeType::CREDIT_ADD->value];
-        yield 'legacy/unknown' => ['legacy_reason_not_in_enum', 'unknown'];
+        yield 'known reason' =>
+            [['reason' => CreditChangeType::CREDIT_ADD->value], CreditChangeType::CREDIT_ADD->value];
+        yield 'legacy/unknown' => [['reason' => 'legacy_reason_not_in_enum'], 'unknown'];
+        yield 'missing reason key' => [[], 'unknown'];
     }
 
     #[DataProvider('reasonProvider')]
-    public function testCreditHistoryMapsReasonType(string $storedReason, string $expectedType): void
+    public function testCreditHistoryMapsReasonType(array $extraParameterFields, string $expectedType): void
     {
         $userData = $this->client->getContainer()->get(UserRepository::class)
             ->findItemByPhoneNumber(self::USER_PHONE_NUMBER);
@@ -78,7 +80,7 @@ class UserCreditHistoryTest extends BikeSharingWebTestCase
             $userData['userId'],
             0,
             Action::CREDIT_CHANGE,
-            json_encode(['amount' => 1.0, 'balance' => 1.0, 'reason' => $storedReason], JSON_THROW_ON_ERROR)
+            json_encode(array_merge(['amount' => 1.0, 'balance' => 1.0], $extraParameterFields), JSON_THROW_ON_ERROR)
         );
         $user = $this->client->getContainer()->get(UserProvider::class)->loadUserByIdentifier(self::USER_PHONE_NUMBER);
         $this->client->loginUser($user);

--- a/tests/Application/Controller/Api/User/UserCreditHistoryTest.php
+++ b/tests/Application/Controller/Api/User/UserCreditHistoryTest.php
@@ -6,9 +6,12 @@ namespace BikeShare\Test\Application\Controller\Api\User;
 
 use BikeShare\App\Security\UserProvider;
 use BikeShare\Credit\CreditSystemInterface;
+use BikeShare\Enum\Action;
 use BikeShare\Enum\CreditChangeType;
+use BikeShare\Repository\HistoryRepository;
 use BikeShare\Repository\UserRepository;
 use BikeShare\Test\Application\BikeSharingWebTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\HttpFoundation\Request;
 
 class UserCreditHistoryTest extends BikeSharingWebTestCase
@@ -58,5 +61,31 @@ class UserCreditHistoryTest extends BikeSharingWebTestCase
     {
         $this->client->request(Request::METHOD_GET, '/api/v1/me/credit-history');
         $this->assertResponseStatusCodeSame(401);
+    }
+
+    public static function reasonProvider(): iterable
+    {
+        yield 'known reason' => [CreditChangeType::CREDIT_ADD->value, CreditChangeType::CREDIT_ADD->value];
+        yield 'legacy/unknown' => ['legacy_reason_not_in_enum', 'unknown'];
+    }
+
+    #[DataProvider('reasonProvider')]
+    public function testCreditHistoryMapsReasonType(string $storedReason, string $expectedType): void
+    {
+        $userData = $this->client->getContainer()->get(UserRepository::class)
+            ->findItemByPhoneNumber(self::USER_PHONE_NUMBER);
+        $this->client->getContainer()->get(HistoryRepository::class)->addItem(
+            $userData['userId'],
+            0,
+            Action::CREDIT_CHANGE,
+            json_encode(['amount' => 1.0, 'balance' => 1.0, 'reason' => $storedReason], JSON_THROW_ON_ERROR)
+        );
+        $user = $this->client->getContainer()->get(UserProvider::class)->loadUserByIdentifier(self::USER_PHONE_NUMBER);
+        $this->client->loginUser($user);
+
+        $this->client->request(Request::METHOD_GET, '/api/v1/me/credit-history');
+
+        $this->assertResponseIsSuccessful(); // 200, not 500 - the actual regression
+        $this->assertSame($expectedType, $this->decodeApiResponseData()[0]['type']);
     }
 }

--- a/tests/Unit/Credit/CreditSystemTest.php
+++ b/tests/Unit/Credit/CreditSystemTest.php
@@ -210,14 +210,14 @@ class CreditSystemTest extends TestCase
             ]);
 
         $creditSystem = new CreditSystem(
-            true,
-            '€',
-            9,
-            2,
-            0,
-            5,
-            10,
-            5,
+            true, //isEnabled
+            '€', //creditCurrency
+            9, //minRequiredCredit
+            2, //rentalFee
+            0, //priceCycle
+            5, //longRentalFee
+            10, //limitIncreaseFee
+            5, //violationFee
             $this->createStub(DbInterface::class),
             $historyRepository
         );

--- a/tests/Unit/Credit/CreditSystemTest.php
+++ b/tests/Unit/Credit/CreditSystemTest.php
@@ -181,7 +181,14 @@ class CreditSystemTest extends TestCase
         $this->assertEquals(0, $creditSystem->getUserCredit($userId));
     }
 
-    public function testGetUserCreditHistoryParsesKnownReason()
+    public static function creditHistoryReasonProvider(): iterable
+    {
+        yield 'known reason' => ['coupon_redemption', 'coupon_redemption'];
+        yield 'unrecognized reason maps to unknown' => ['some_legacy_reason_no_longer_in_the_enum', 'unknown'];
+    }
+
+    #[DataProvider('creditHistoryReasonProvider')]
+    public function testGetUserCreditHistoryMapsReasonType(string $storedReason, string $expectedType): void
     {
         $userId = 1;
         $historyRepository = $this->createMock(HistoryRepository::class);
@@ -196,7 +203,7 @@ class CreditSystemTest extends TestCase
                     'parameter' => json_encode([
                         'amount' => 3.5,
                         'balance' => 10.0,
-                        'reason' => 'coupon_redemption',
+                        'reason' => $storedReason,
                     ], JSON_THROW_ON_ERROR),
                 ],
             ]);
@@ -217,51 +224,8 @@ class CreditSystemTest extends TestCase
         $result = $creditSystem->getUserCreditHistory($userId);
 
         $this->assertCount(1, $result);
-        $this->assertEquals('coupon_redemption', $result[0]['type']);
+        $this->assertEquals($expectedType, $result[0]['type']);
         $this->assertEquals(3.5, $result[0]['amount']);
         $this->assertEquals(10.0, $result[0]['balance']);
-    }
-
-    public function testGetUserCreditHistoryMapsUnrecognizedReasonToUnknownInsteadOfFatalError()
-    {
-        // Regresses the bug sveneld found in review: tryFrom() returns null for a
-        // reason string outside the current CreditChangeType enum (e.g. a value
-        // written by an older code version before a case was renamed/removed),
-        // and calling ->value directly on that null used to fatal with strict_types
-        // on, before the `??` ever got a chance to fall back to 'unknown'.
-        $userId = 1;
-        $historyRepository = $this->createMock(HistoryRepository::class);
-        $historyRepository->expects($this->once())
-            ->method('findCreditHistoryByUser')
-            ->willReturn([
-                [
-                    'id' => 1,
-                    'time' => '2026-01-01 12:00:00',
-                    'action' => 5,
-                    'parameter' => json_encode([
-                        'amount' => 1.0,
-                        'balance' => 4.0,
-                        'reason' => 'some_legacy_reason_no_longer_in_the_enum',
-                    ], JSON_THROW_ON_ERROR),
-                ],
-            ]);
-
-        $creditSystem = new CreditSystem(
-            true,
-            '€',
-            9,
-            2,
-            0,
-            5,
-            10,
-            5,
-            $this->createStub(DbInterface::class),
-            $historyRepository
-        );
-
-        $result = $creditSystem->getUserCreditHistory($userId);
-
-        $this->assertCount(1, $result);
-        $this->assertEquals('unknown', $result[0]['type']);
     }
 }

--- a/tests/Unit/Credit/CreditSystemTest.php
+++ b/tests/Unit/Credit/CreditSystemTest.php
@@ -183,12 +183,14 @@ class CreditSystemTest extends TestCase
 
     public static function creditHistoryReasonProvider(): iterable
     {
-        yield 'known reason' => ['coupon_redemption', 'coupon_redemption'];
-        yield 'unrecognized reason maps to unknown' => ['some_legacy_reason_no_longer_in_the_enum', 'unknown'];
+        yield 'known reason' => [['reason' => 'coupon_redemption'], 'coupon_redemption'];
+        yield 'unrecognized reason maps to unknown' =>
+            [['reason' => 'some_legacy_reason_no_longer_in_the_enum'], 'unknown'];
+        yield 'missing reason key maps to unknown' => [[], 'unknown'];
     }
 
     #[DataProvider('creditHistoryReasonProvider')]
-    public function testGetUserCreditHistoryMapsReasonType(string $storedReason, string $expectedType): void
+    public function testGetUserCreditHistoryMapsReasonType(array $extraParameterFields, string $expectedType): void
     {
         $userId = 1;
         $historyRepository = $this->createMock(HistoryRepository::class);
@@ -200,11 +202,10 @@ class CreditSystemTest extends TestCase
                     'id' => 1,
                     'time' => '2026-01-01 12:00:00',
                     'action' => 5,
-                    'parameter' => json_encode([
-                        'amount' => 3.5,
-                        'balance' => 10.0,
-                        'reason' => $storedReason,
-                    ], JSON_THROW_ON_ERROR),
+                    'parameter' => json_encode(
+                        array_merge(['amount' => 3.5, 'balance' => 10.0], $extraParameterFields),
+                        JSON_THROW_ON_ERROR
+                    ),
                 ],
             ]);
 

--- a/tests/Unit/Credit/CreditSystemTest.php
+++ b/tests/Unit/Credit/CreditSystemTest.php
@@ -180,4 +180,88 @@ class CreditSystemTest extends TestCase
 
         $this->assertEquals(0, $creditSystem->getUserCredit($userId));
     }
+
+    public function testGetUserCreditHistoryParsesKnownReason()
+    {
+        $userId = 1;
+        $historyRepository = $this->createMock(HistoryRepository::class);
+        $historyRepository->expects($this->once())
+            ->method('findCreditHistoryByUser')
+            ->with($userId, 1000)
+            ->willReturn([
+                [
+                    'id' => 1,
+                    'time' => '2026-01-01 12:00:00',
+                    'action' => 5,
+                    'parameter' => json_encode([
+                        'amount' => 3.5,
+                        'balance' => 10.0,
+                        'reason' => 'coupon_redemption',
+                    ], JSON_THROW_ON_ERROR),
+                ],
+            ]);
+
+        $creditSystem = new CreditSystem(
+            true,
+            '€',
+            9,
+            2,
+            0,
+            5,
+            10,
+            5,
+            $this->createStub(DbInterface::class),
+            $historyRepository
+        );
+
+        $result = $creditSystem->getUserCreditHistory($userId);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('coupon_redemption', $result[0]['type']);
+        $this->assertEquals(3.5, $result[0]['amount']);
+        $this->assertEquals(10.0, $result[0]['balance']);
+    }
+
+    public function testGetUserCreditHistoryMapsUnrecognizedReasonToUnknownInsteadOfFatalError()
+    {
+        // Regresses the bug sveneld found in review: tryFrom() returns null for a
+        // reason string outside the current CreditChangeType enum (e.g. a value
+        // written by an older code version before a case was renamed/removed),
+        // and calling ->value directly on that null used to fatal with strict_types
+        // on, before the `??` ever got a chance to fall back to 'unknown'.
+        $userId = 1;
+        $historyRepository = $this->createMock(HistoryRepository::class);
+        $historyRepository->expects($this->once())
+            ->method('findCreditHistoryByUser')
+            ->willReturn([
+                [
+                    'id' => 1,
+                    'time' => '2026-01-01 12:00:00',
+                    'action' => 5,
+                    'parameter' => json_encode([
+                        'amount' => 1.0,
+                        'balance' => 4.0,
+                        'reason' => 'some_legacy_reason_no_longer_in_the_enum',
+                    ], JSON_THROW_ON_ERROR),
+                ],
+            ]);
+
+        $creditSystem = new CreditSystem(
+            true,
+            '€',
+            9,
+            2,
+            0,
+            5,
+            10,
+            5,
+            $this->createStub(DbInterface::class),
+            $historyRepository
+        );
+
+        $result = $creditSystem->getUserCreditHistory($userId);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('unknown', $result[0]['type']);
+    }
 }


### PR DESCRIPTION
## Summary

Two things in `CreditSystem::getUserCreditHistory()`:

- `json_decode($parameter, true, JSON_THROW_ON_ERROR)` — the flag landed in the `$depth` parameter position, not `$flags`. `JSON_THROW_ON_ERROR` never actually applies, so malformed JSON silently decodes to `null` instead of throwing. This is a real, currently-live bug.
- Hardening (not an active crash for ordinary data): `CreditChangeType::tryFrom($jsonData['reason'])->value ?? 'unknown'` looked like it could fatal on an unrecognized reason string, but it doesn't - `tryFrom()` returns `null` cleanly for that, and `null->value` is a warning in PHP 8, not fatal. The actual crash path, found during review, is `tryFrom(null)` itself: `CreditChangeType::tryFrom()`'s parameter is `int|string`, not nullable, so if `$jsonData['reason']` is missing entirely or explicitly `null`, `tryFrom()` throws a `TypeError` before any downstream guard on its return value gets a chance to run.

## Fix

- Corrected the `json_decode()` call to pass the flag in the right position.
- `CreditChangeType::tryFrom((string)($jsonData['reason'] ?? ''))` - coerces a missing/null reason to `''`, which `tryFrom()` rejects cleanly (no enum case is an empty string), then falls through to `'unknown'` via an `instanceof CreditChangeType` check on the result.

## Test plan

- [x] Verified the failure mode directly with `php -r` before fixing (`tryFrom('unknown_string')` -> `null`, no exception; `tryFrom(null)` -> `TypeError`)
- [x] Unit test: confirmed the new "missing reason key" case throws before the fix, passes after (reverted the fix locally, watched it fail, restored it, watched it pass)
- [x] Unit + Application-level data providers cover known reason / unrecognized-but-present reason / missing reason key
- [x] `vendor/bin/phpunit tests/Unit` - 279 tests, 6025 assertions, all passing
- [x] `vendor/bin/phpstan analyse` - no errors
- [x] `vendor/bin/phpcs` - clean