### PR TITLE
Remove unimplemented getAffectedRows() and deprecated fetch_assoc()

### DIFF
--- a/src/Db/DbInterface.php
+++ b/src/Db/DbInterface.php
@@ -20,10 +20,5 @@ interface DbInterface
     /**
      * @return int
      */
-    public function getAffectedRows();
-
-    /**
-     * @return int
-     */
     public function getLastInsertId();
 }

--- a/src/Db/PdoDb.php
+++ b/src/Db/PdoDb.php
@@ -42,11 +42,6 @@ class PdoDb implements DbInterface
         return $result;
     }
 
-    public function getAffectedRows(): int
-    {
-        throw new \RuntimeException('Not implemented');
-    }
-
     public function getLastInsertId(): int
     {
         return (int)$this->conn->lastInsertId();

--- a/src/Db/PdoDbResult.php
+++ b/src/Db/PdoDbResult.php
@@ -28,16 +28,6 @@ class PdoDbResult implements DbResultInterface
         return $this->result->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    /**
-     * @phpcs:disable Generic.NamingConventions.CamelCapsFunctionName
-     * @phpcs:disable PSR1.Methods.CamelCapsMethodName
-     */
-    #[\Deprecated(message: 'use fetchAssoc')]
-    public function fetch_assoc(): ?array
-    {
-        return $this->fetchAssoc();
-    }
-
     public function rowCount(): int
     {
         return $this->result->rowCount();


### PR DESCRIPTION
## Summary

- `DbInterface::getAffectedRows()` / `PdoDb::getAffectedRows()` always threw `RuntimeException('Not implemented')` and had zero real call sites - a dead interface member masquerading as a working method.
- `PdoDbResult::fetch_assoc()` was a deprecated snake_case alias for `fetchAssoc()` with zero call sites.

Both removed entirely rather than left as unreachable code.

## Test plan

- [x] `vendor/bin/phpstan analyse` - no errors
- [x] `vendor/bin/phpcs` - clean
- [x] `vendor/bin/phpunit tests/Unit` - 276/276, 6004 assertions