### PR TITLE
Refactor coupon status to use CouponStatus enum

### DIFF
--- a/src/Controller/Api/V1/Admin/CouponsController.php
+++ b/src/Controller/Api/V1/Admin/CouponsController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Controller\Api\V1\Admin;
 
+use BikeShare\Enum\CouponStatus;
 use BikeShare\Credit\CodeGenerator\CodeGeneratorInterface;
 use BikeShare\Credit\CreditSystemInterface;
 use BikeShare\Repository\CouponRepository;
@@ -42,7 +43,7 @@ class CouponsController extends AbstractController
             return $this->json(['detail' => 'Credit system is disabled'], Response::HTTP_BAD_REQUEST);
         }
 
-        $this->couponRepository->updateStatus($coupon, 1); // Mark as sold
+        $this->couponRepository->updateStatus($coupon, CouponStatus::SOLD); // Mark as sold
 
         return $this->json([
             'message' => 'Coupon ' . $coupon . ' sold.',

--- a/src/Controller/Api/V1/CouponsController.php
+++ b/src/Controller/Api/V1/CouponsController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Controller\Api\V1;
 
+use BikeShare\Enum\CouponStatus;
 use BikeShare\Credit\CreditSystemInterface;
 use BikeShare\Repository\CouponRepository;
 use BikeShare\Enum\CreditChangeType;
@@ -38,7 +39,7 @@ class CouponsController extends AbstractController
             );
         }
 
-        $this->couponRepository->updateStatus($coupon, 2);// Mark as used
+        $this->couponRepository->updateStatus($coupon, CouponStatus::USED);// Mark as used
         $this->creditSystem->increaseCredit(
             $this->getUser()->getUserId(),
             (float)$couponData['value'],

--- a/src/Enum/CouponStatus.php
+++ b/src/Enum/CouponStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BikeShare\Enum;
+
+enum CouponStatus: int
+{
+    case ACTIVE = 0;
+    case SOLD = 1;
+    case USED = 2;
+}

--- a/src/Repository/CouponRepository.php
+++ b/src/Repository/CouponRepository.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace BikeShare\Repository;
 
 use BikeShare\Db\DbInterface;
+use BikeShare\Enum\CouponStatus;
 
-#@TODO: Refactor the status field to use an enum for better type safety and clarity.
 class CouponRepository
 {
     public function __construct(private readonly DbInterface $db)
@@ -22,16 +22,12 @@ class CouponRepository
         return $coupons;
     }
 
-    public function updateStatus(string $coupon, int $status): void
+    public function updateStatus(string $coupon, CouponStatus $status): void
     {
-        if (!in_array($status, [0, 1, 2], true)) {
-            throw new \InvalidArgumentException('Invalid status value. Must be 0, 1, or 2.');
-        }
-
         $this->db->query(
             'UPDATE coupons SET status = :status WHERE coupon = :coupon LIMIT 1',
             [
-                'status' => $status,
+                'status' => $status->value,
                 'coupon' => $coupon,
             ]
         );


### PR DESCRIPTION
Coupon status was still using magic ints (0/1/2) with comments explaining what each one means. Replaced with a CouponStatus enum, same pattern StandRepository already uses for stands (StandStatus). Removes the manual in_array() check in updateStatus() too - the enum type already guarantees a valid value, so it wasn't doing anything anymore once the parameter type changed.