### PR TITLE
Require ext-intl explicitly and install it on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          extensions: intl
 
       - name: Install dependencies
         run: composer install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          extensions: intl
 
       - name: Install dependencies
         run: composer install

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "php": "^8.4",
     "ext-curl": "*",
     "ext-gettext": "*",
+    "ext-intl": "*",
     "ext-json": "*",
     "ext-mysqli": "*",
     "ext-pdo": "*",


### PR DESCRIPTION
Found while investigating the CI failure on PR #358 (unrelated to that PR - reproduces on a clean main checkout too, see discussion there).

The app uses ICU MessageFormat translations (IntlFormatter) but never declared ext-intl as a dependency. Reproduced locally: without ext-intl installed, template rendering throws (no symfony/polyfill-intl-messageformatter fallback declared either). Likely the same root cause behind UserControllerTest::testChangePassword failing on CI.

- composer.json: added ext-intl to require, so composer install fails loudly if it's missing instead of the app breaking silently later
- build.yml: explicitly install intl in the setup-php step