### PR TITLE
Raise PHPStan level to 5, fix the 18 new errors

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,12 +7,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Call to an undefined method Symfony\\Component\\Security\\Core\\User\\UserInterface\:\:getUserId\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/App/Security/UserConfirmedEmailChecker.php
-
-		-
 			message: '#^Call to an undefined method Symfony\\Component\\Security\\Core\\User\\PasswordAuthenticatedUserInterface\:\:getCity\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -88,18 +82,6 @@ parameters:
 			message: '#^Call to an undefined method Symfony\\Component\\Security\\Core\\User\\UserInterface\:\:getUserId\(\)\.$#'
 			identifier: method.notFound
 			count: 1
-			path: src/Controller/Api/V1/AuthController.php
-
-		-
-			message: '#^Call to an undefined method Symfony\\Component\\Security\\Core\\User\\UserInterface\:\:isNumberConfirmed\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: src/Controller/Api/V1/AuthController.php
-
-		-
-			message: '#^Call to an undefined method Symfony\\Component\\Security\\Core\\User\\UserInterface\:\:getUserId\(\)\.$#'
-			identifier: method.notFound
-			count: 1
 			path: src/Controller/Api/V1/CouponsController.php
 
 		-
@@ -167,15 +149,3 @@ parameters:
 			identifier: method.notFound
 			count: 2
 			path: src/Controller/ScanController.php
-
-		-
-			message: '#^Call to an undefined method Symfony\\Component\\Security\\Core\\User\\UserInterface\:\:getEmail\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Controller/SecurityController.php
-
-		-
-			message: '#^Call to an undefined method Symfony\\Component\\Security\\Core\\User\\UserInterface\:\:getUserId\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/Controller/SmsRequestController.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
-    level: 4
+    level: 5
     paths:
         - src
         - tests

--- a/src/App/Security/TokenProvider.php
+++ b/src/App/Security/TokenProvider.php
@@ -32,7 +32,6 @@ class TokenProvider implements TokenProviderInterface
             $row = $result->fetchAssoc();
 
             $this->tokens[$series] = new PersistentToken(
-                $row['class'],
                 $row['username'],
                 $row['series'],
                 $row['value'],
@@ -51,7 +50,6 @@ class TokenProvider implements TokenProviderInterface
         $currentToken = $this->loadTokenBySeries($series);
 
         $token = new PersistentToken(
-            $currentToken->getClass(),
             $currentToken->getUserIdentifier(),
             $series,
             $tokenValue,

--- a/src/App/Security/UserConfirmedEmailChecker.php
+++ b/src/App/Security/UserConfirmedEmailChecker.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\App\Security;
 
+use BikeShare\App\Entity\User;
 use BikeShare\Event\UserReconfirmationEvent;
 use BikeShare\Repository\RegistrationRepository;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
@@ -26,6 +27,10 @@ class UserConfirmedEmailChecker implements UserCheckerInterface
 
     public function checkPostAuth(UserInterface $user): void
     {
+        if (!$user instanceof User) {
+            return;
+        }
+
         $confirmation = $this->registrationRepository->findItemByUserId($user->getUserId());
         if (!empty($confirmation)) {
             // Carry the userKey read here into the event so the listener never re-queries

--- a/src/App/Security/UserProvider.php
+++ b/src/App/Security/UserProvider.php
@@ -33,7 +33,7 @@ class UserProvider implements UserProviderInterface, PasswordUpgraderInterface
      *
      * @throws UserNotFoundException if the user is not found
      */
-    public function loadUserByIdentifier(string $identifier): UserInterface
+    public function loadUserByIdentifier(string $identifier): User
     {
         try {
             $identifier = $this->phonePurifier->purify($identifier);

--- a/src/Controller/QrCodeGeneratorController.php
+++ b/src/Controller/QrCodeGeneratorController.php
@@ -103,7 +103,7 @@ class QrCodeGeneratorController extends AbstractController
 
         $pdf->AddPage();
         // QRCODE,M : QR-CODE Medium error correction
-        $pdf->write2DBarcode($url, 'QRCODE,M', '', 18, '', 90, $style, 'N');
+        $pdf->write2DBarcode($url, 'QRCODE,M', null, 18, null, 90, $style, 'N');
         $pdf->MultiCell(0, 0, $text, 0, 'C', false, 0);
     }
 }

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BikeShare\Controller;
 
+use BikeShare\App\Entity\User;
 use BikeShare\App\Security\UserProvider;
 use BikeShare\Form\ChangePasswordFormType;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -22,6 +23,10 @@ class UserController extends AbstractController
         TranslatorInterface $translator
     ): Response {
         $user = $this->getUser();
+        if (!$user instanceof User) {
+            throw $this->createAccessDeniedException();
+        }
+
         $form = $this->createForm(ChangePasswordFormType::class);
         $form->handleRequest($request);
 

--- a/tests/Application/BikeSharingWebTestCase.php
+++ b/tests/Application/BikeSharingWebTestCase.php
@@ -120,7 +120,7 @@ abstract class BikeSharingWebTestCase extends WebTestCase
                 $found,
                 sprintf(
                     'Expected %s log matching %s but did not find it.',
-                    Logger::getLevelName((int)$expected['level']),
+                    Level::from((int)$expected['level'])->getName(),
                     \is_callable($expected['pattern']) ? 'closure' : $expected['pattern']
                 )
             );

--- a/tests/Application/Controller/SmsRequestController/CreditCommandTest.php
+++ b/tests/Application/Controller/SmsRequestController/CreditCommandTest.php
@@ -37,6 +37,7 @@ class CreditCommandTest extends BikeSharingWebTestCase
         $sentMessage = $smsSender->getSentMessages()[0];
 
         $creditSystem = $this->client->getContainer()->get(CreditSystemInterface::class);
+        $this->assertInstanceOf(CreditSystemInterface::class, $creditSystem);
 
         $this->assertInstanceOf(TranslatableMessage::class, $sentMessage['message']);
         $this->assertSame('command.credit.message', $sentMessage['message']->getMessage());

--- a/tests/Integration/BikeSharingKernelTestCase.php
+++ b/tests/Integration/BikeSharingKernelTestCase.php
@@ -72,7 +72,7 @@ abstract class BikeSharingKernelTestCase extends WebTestCase
                 $found,
                 sprintf(
                     'Expected %s log matching %s but did not find it.',
-                    Logger::getLevelName((int)$expected['level']),
+                    Level::from((int)$expected['level'])->getName(),
                     \is_callable($expected['pattern']) ? 'closure' : $expected['pattern']
                 )
             );


### PR DESCRIPTION
You asked to try bumping phpstan to level 5 and see how many errors come up - 18. Fixed all of them.

Most of it (12 of 18) was one root cause: `UserProvider::loadUserByIdentifier()` was typed to return the generic `UserInterface` even though it always builds and returns our own `User`. Narrowed the return type to `User`, which fixed 7 errors on its own in AuthController/SecurityController/SmsRequestController. Added `instanceof User` guards where the method signature comes from an interface I can't change (`UserCheckerInterface`, `AbstractController::getUser()`).

Also: `TokenProvider` was using Symfony's deprecated 5-arg `PersistentToken` constructor (the user-class arg they're removing in 8.0), `write2DBarcode()` got `''` instead of `null` for auto x/w, two tests called the now-generic-typed `Logger::getLevelName()` with a plain int, and one test needed an `assertInstanceOf()` because `container->get(SomeInterface::class)` can't be resolved to a concrete type by phpstan-symfony.

Dropped 5 baseline entries that these fixes made stale (`ignore.unmatched` confirmed it, not a guess). Left the other 24 baseline entries alone - the comment at the top of the file says that's deliberately deferred for a UserProvider rework, wasn't part of this.

phpstan level 5 clean, phpcs clean, full suite (492 tests) green.